### PR TITLE
Revert back to golang's mail/mime parser.

### DIFF
--- a/cmd/maildir-tools/messages_cmd.go
+++ b/cmd/maildir-tools/messages_cmd.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 
 	"github.com/google/subcommands"
-	"github.com/jhillyerd/enmime"
 	"github.com/skx/maildir-tools/finder"
+	"github.com/skx/maildir-tools/mailreader"
 )
 
 // messageCmd holds the state for this sub-command
@@ -105,23 +105,9 @@ func (p *messagesCmd) GetMessages(path string, format string) ([]SingleMessage, 
 	for index, msg := range files {
 
 		//
-		// Open it
+		// Get the mail
 		//
-		file, err := os.Open(msg)
-		if err != nil {
-			return messages, fmt.Errorf("failed to open %s - %s", path, err.Error())
-		}
-
-		// Parse message body with enmime.
-		env, err := enmime.ReadEnvelope(file)
-		if err != nil {
-			return messages, err
-		}
-
-		//
-		// Ensure we don't leak.
-		//
-		file.Close()
+		mail := mailreader.New(msg)
 
 		r := regexp.MustCompile("^([0-9]+)(.*)$")
 
@@ -166,7 +152,7 @@ func (p *messagesCmd) GetMessages(path string, format string) ([]SingleMessage, 
 			case "total":
 				ret = fmt.Sprintf("%d", len(files))
 			default:
-				ret = env.GetHeader(field)
+				ret, _ = mail.Header(field)
 			}
 
 			if padding != "" {

--- a/cmd/maildir-tools/messages_cmd.go
+++ b/cmd/maildir-tools/messages_cmd.go
@@ -1,6 +1,4 @@
-//
 // Show messages in the given Maildir folder.
-//
 
 package main
 
@@ -107,7 +105,10 @@ func (p *messagesCmd) GetMessages(path string, format string) ([]SingleMessage, 
 		//
 		// Get the mail
 		//
-		mail := mailreader.New(msg)
+		mail, err := mailreader.New(msg)
+		if err != nil {
+			return messages, err
+		}
 
 		r := regexp.MustCompile("^([0-9]+)(.*)$")
 
@@ -152,7 +153,7 @@ func (p *messagesCmd) GetMessages(path string, format string) ([]SingleMessage, 
 			case "total":
 				ret = fmt.Sprintf("%d", len(files))
 			default:
-				ret, _ = mail.Header(field)
+				ret = mail.Header(field)
 			}
 
 			if padding != "" {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/skx/maildir-tools
 
 go 1.13
+
+require (
+	github.com/gizak/termui/v3 v3.1.0
+	github.com/google/subcommands v1.0.1
+	github.com/jhillyerd/enmime v0.7.0
+)

--- a/mailreader/mailreader.go
+++ b/mailreader/mailreader.go
@@ -1,61 +1,145 @@
-// Package mailreader allows reading a single email from disk.
+// Package mailreader allows reading a single email from disk to
+// return the body and header-values by name.
+//
+// If we want to be fast we use the golang mail.* package, which
+// is great for retrieving (& decoding) header-values.  However it
+// doesn't provide easy access to the message body for complex
+// cases of multipart/alternative and similar MIME messages.
+//
+// To handle the case of accessing the body of an email in a
+// reliable fashion we embed Enmime and use that if we need the
+// body.   Because opening and parsing a message two times is
+// grossly inefficient the caller needs to use the appropriate
+// constructor and know what they want to acces.
+//
+// Header-only access?  Fast?  Use New().
+//
+// Need the body?  Use NewEnmime.
 package mailreader
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"mime"
 	"net/mail"
+	"os"
+
+	"github.com/jhillyerd/enmime"
 )
 
 // Email holds the state for this message-object.
 type Email struct {
 
-	// Filename holds the name of the file we're reading
+	// Filename holds the name of the file we're reading.
 	Filename string
 
-	// Message holds the mail message
+	// Message holds the mail message - if we're using
+	// the golang parser (which we do for message-indexes
+	// as it is faster).
 	Message *mail.Message
+
+	// Enmime holds the enmime handle to the message,
+	// which we use when we want access to the body
+	// attachments (TODO), etc.
+	Enmime *enmime.Envelope
+
+	// Use enmime?
+	_enmime bool
 }
 
-// New creates a new mail-reading object
-func New(file string) *Email {
-	return &Email{Filename: file, Message: nil}
-}
+// New creates a new mail-reading object which will use the
+// golang mail-package to parse the message.
+//
+// Using this function will allow you access to the header-values
+// easily, but not the message-body.
+func New(file string) (*Email, error) {
+	x := &Email{Filename: file}
 
-func (m *Email) readMessage() error {
 	var content []byte
 	var err error
 
-	content, err = ioutil.ReadFile(m.Filename)
+	content, err = ioutil.ReadFile(file)
 	if err != nil {
-		return err
+		return x, err
 	}
 
-	m.Message, err = mail.ReadMessage(bytes.NewReader(content))
+	x.Message, err = mail.ReadMessage(bytes.NewReader(content))
 	if err != nil {
-		return err
+		return x, err
 	}
-	return nil
+
+	return x, nil
 }
 
-// Header returns the value of the given message
-func (m *Email) Header(name string) (string, error) {
-	if m.Message == nil {
-		err := m.readMessage()
-		if err != nil {
-			return "", err
-		}
+// NewEnmime creates a new mail-reading object which uses the enmime
+// library.
+//
+// Using this method is required if you wish to read the body of an
+// email in a form suitable for rendering.  It is slower than the
+// golang-native approach which is why the user must opt-into it.
+func NewEnmime(file string) (*Email, error) {
+	x := &Email{Filename: file, _enmime: true}
+
+	var err error
+	var f *os.File
+
+	f, err = os.Open(file)
+	if err != nil {
+		return x, fmt.Errorf("failed to open %s - %s", file, err.Error())
 	}
+
+	// Parse message body with enmime.
+	x.Enmime, err = enmime.ReadEnvelope(f)
+	if err != nil {
+		return x, err
+	}
+
+	// Ensure we don't leak.
+	f.Close()
+
+	return x, nil
+}
+
+// Header returns the value of the given header from within our message.
+//
+// Header values are RFC2047-decoded.
+func (m *Email) Header(name string) string {
+
+	// Split handling.
+	if m._enmime {
+		return m.Enmime.GetHeader(name)
+	}
+
+	// Get the header using the native-method.
+	value := m.Message.Header.Get(name)
 
 	// GO 1.5 does not decode headers, but this may change in
 	// future releases...
-	value := m.Message.Header.Get(name)
-
 	decoded, err := (&mime.WordDecoder{}).DecodeHeader(value)
 	if err != nil || len(decoded) == 0 {
-		return value, nil
+		return value
 	}
-	return decoded, nil
+	return decoded
+}
 
+// Body returns the body of an email message, in a useful format.
+// That means that if a 'text/plain' part is present it will be
+// returned, otherwise we'll use 'text/html'.  If neither part
+// is present then the raw body will be returned.
+func (m *Email) Body() string {
+
+	if m._enmime {
+		// Try to work out what to return
+		if len(m.Enmime.Text) > 0 {
+			return m.Enmime.Text
+		} else if len(m.Enmime.HTML) > 0 {
+			return m.Enmime.HTML
+		}
+
+	}
+
+	// TODO - open the file.  Read until we hit
+	// a newline, then return the contents.
+	return "No body available.  Sorry!"
 }

--- a/mailreader/mailreader.go
+++ b/mailreader/mailreader.go
@@ -1,0 +1,50 @@
+// Package mailreader allows reading a single email from disk.
+package mailreader
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/mail"
+)
+
+// Email holds the state for this message-object.
+type Email struct {
+
+	// Filename holds the name of the file we're reading
+	Filename string
+
+	// Message holds the mail message
+	Message *mail.Message
+}
+
+// New creates a new mail-reading object
+func New(file string) *Email {
+	return &Email{Filename: file, Message: nil}
+}
+
+func (m *Email) readMessage() error {
+	var content []byte
+	var err error
+
+	content, err = ioutil.ReadFile(m.Filename)
+	if err != nil {
+		return err
+	}
+
+	m.Message, err = mail.ReadMessage(bytes.NewReader(content))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Header returns the value of the given message
+func (m *Email) Header(name string) (string, error) {
+	if m.Message == nil {
+		err := m.readMessage()
+		if err != nil {
+			return "", err
+		}
+	}
+	return m.Message.Header.Get(name), nil
+}

--- a/mailreader/mailreader.go
+++ b/mailreader/mailreader.go
@@ -4,6 +4,7 @@ package mailreader
 import (
 	"bytes"
 	"io/ioutil"
+	"mime"
 	"net/mail"
 )
 
@@ -46,5 +47,15 @@ func (m *Email) Header(name string) (string, error) {
 			return "", err
 		}
 	}
-	return m.Message.Header.Get(name), nil
+
+	// GO 1.5 does not decode headers, but this may change in
+	// future releases...
+	value := m.Message.Header.Get(name)
+
+	decoded, err := (&mime.WordDecoder{}).DecodeHeader(value)
+	if err != nil || len(decoded) == 0 {
+		return value, nil
+	}
+	return decoded, nil
+
 }


### PR DESCRIPTION
This is much much much faster than enmime, and makes us more responsive.

This will close #4 when complete, but for now we're missing the text/plain or text/html body-reading.
