### PR TITLE
Added simple formatting routine.

### DIFF
--- a/cmd/maildir-tools/ui_cmd.go
+++ b/cmd/maildir-tools/ui_cmd.go
@@ -52,7 +52,7 @@ type uiCmd struct {
 func (p *uiCmd) getMaildirs() {
 
 	helper := &maildirsCmd{prefix: p.prefix,
-		format: "${06unread}/${06total} - ${name}"}
+		format: "#{06unread}/#{06total} - #{name}"}
 	p.maildirs = helper.GetMaildirs()
 
 }
@@ -77,7 +77,7 @@ func (p *uiCmd) getMessages() {
 	//
 	helper := &messagesCmd{}
 	var err error
-	p.messages, err = helper.GetMessages(curMaildir, "[${06index}/${06total} [${4flags}] ${subject}")
+	p.messages, err = helper.GetMessages(curMaildir, "[#{06index}/#{06total} [#{4flags}] #{subject}")
 	if err != nil {
 		ui.Close()
 		panic(err)

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,79 @@
+// Package formatter allows expanding variables inside template-strings.
+//
+// This is almost a direct port of `os.Expand`, however there is support
+// for using field-sizes as well as different deliminators.
+package formatter
+
+import (
+	"regexp"
+	"strconv"
+)
+
+var (
+	// Helper lets us find variables to expand.
+	helper = regexp.MustCompile("^(.*?)#{([^}]+)}(.*)$")
+
+	// Length specifies the field-length.
+	length = regexp.MustCompile("^([0-9]+)(.*)$")
+)
+
+// Expand replaces ${var} or $var in the string based on the mapping function.
+func Expand(format string, mapping func(string) string) string {
+
+	out := ""
+
+	match := helper.FindStringSubmatch(format)
+
+	for len(match) > 0 {
+
+		// Get the field-name we should interpolate.
+		field := match[2]
+
+		//
+		// Look for a padding/truncation setup.
+		//
+		padding := ""
+		pMatches := length.FindStringSubmatch(field)
+		if len(pMatches) > 0 {
+			padding = pMatches[1]
+			field = pMatches[2]
+		}
+
+		// Add the prefix
+		out += match[1]
+
+		// Get the field-value, via the callback
+		output := mapping(field)
+
+		if padding != "" {
+
+			// padding character
+			char := " "
+			if padding[0] == byte('0') {
+				char = "0"
+			}
+
+			// size we need to pad to
+			size, _ := strconv.Atoi(padding)
+			for len(output) < size {
+				output = char + output
+			}
+
+			// or truncate to
+			if len(output) > size {
+				output = output[:size]
+			}
+		}
+
+		// Add the value
+		out += output
+
+		// Move on.
+		format = match[3]
+
+		match = helper.FindStringSubmatch(format)
+	}
+
+	// Add on the format-string if it didn't match.
+	return out + format
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -55,3 +55,53 @@ func TestTruncation(t *testing.T) {
 		t.Errorf("Got unexpected output:" + out)
 	}
 }
+
+func TestName(t *testing.T) {
+
+	mapper := func(placeholderName string) string {
+		switch placeholderName {
+		case "NAME1":
+			return "\"Steve\"<steve@steve.fi>"
+		case "NAME2":
+			return "\"Steve Kemp\"    <steve@steve.fi>"
+		}
+		return ""
+	}
+
+	out := Expand("#{NAME1.name}", mapper)
+	if out != "Steve" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+	out = Expand("#{NAME2.name}", mapper)
+	if out != "Steve Kemp" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+}
+
+func TestEmail(t *testing.T) {
+
+	mapper := func(placeholderName string) string {
+		switch placeholderName {
+		case "NAME":
+			return "\"Steve\"<steve@steve.fi>"
+		case "TEST":
+			return "<steve@steve.fi>"
+		case "TEST2":
+			return "steve@steve.fi"
+		}
+		return ""
+	}
+
+	out := Expand("#{NAME.email}", mapper)
+	if out != "<steve@steve.fi>" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+	out = Expand("#{TEST.email}", mapper)
+	if out != "<steve@steve.fi>" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+	out = Expand("#{TEST2.email}", mapper)
+	if out != "steve@steve.fi" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,57 @@
+package formatter
+
+import (
+	"testing"
+)
+
+func TestBasic(t *testing.T) {
+
+	mapper := func(placeholderName string) string {
+		switch placeholderName {
+		case "DAY_PART":
+			return "morning"
+		case "NAME":
+			return "Gopher"
+
+		}
+		return ""
+	}
+
+	out := Expand("Good #{DAY_PART}, #{NAME}!", mapper)
+
+	if out != "Good morning, Gopher!" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+}
+
+func TestPadding(t *testing.T) {
+
+	mapper := func(placeholderName string) string {
+		switch placeholderName {
+		case "FLAGS":
+			return "SRF"
+		}
+		return ""
+	}
+
+	out := Expand("#{06FLAGS}", mapper)
+	if out != "000SRF" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+}
+
+func TestTruncation(t *testing.T) {
+
+	mapper := func(placeholderName string) string {
+		switch placeholderName {
+		case "NAME":
+			return "STEVE KEMP"
+		}
+		return ""
+	}
+
+	out := Expand("#{04NAME}", mapper)
+	if out != "STEV" {
+		t.Errorf("Got unexpected output:" + out)
+	}
+}


### PR DESCRIPTION
This pull-request creates a reusable library for field-formatting, which uses a more friendly syntax for shell-usage.

i.e. Running "maildir-tools messages --format "${to}" people-steve" is a pain, because the shell replaces `${to}` with ``.

This will close #6 when complete.  For the moment we have a library, with test-cases, that:

* This handles field-lookup, via callback.
* This handles truncation, and padding.

TODO

* Use it.
* Allow email-handling.
   * "#{to}" is fine but `#{to.name}` and `#{to.email}` will be require.d
   * The same goes for any other field that should be an address.