### PR TITLE
Implement delete-message functionality

### DIFF
--- a/cmd/maildir-tools/ui_cmd.go
+++ b/cmd/maildir-tools/ui_cmd.go
@@ -112,6 +112,50 @@ func (p *uiCmd) getMessage() []string {
 	return strings.Split(out, "\n")
 }
 
+// deleteCurrentMessage is called in either the message-list mode,
+// or in the message-view mode.  It deletes the current message
+// in either case.
+func (p *uiCmd) deleteCurrentMessage() {
+
+	// Delete from the message-index
+	if p.mode == "messages" {
+
+		// Get the selected message
+		i := p.messageList.SelectedRow
+
+		// If we don't have one, something is weird.
+		if i < 0 {
+			return
+		}
+
+		// Get the file on-disk
+		file := p.messages[i].Path
+
+		// Delete it
+		os.Remove(file)
+
+		// Refresh the message-list
+		// Update our list of messages
+		p.getMessages()
+
+		// Reset our UI
+		p.messageList.Rows = []string{}
+
+		for _, r := range p.messages {
+			p.messageList.Rows = append(p.messageList.Rows, r.Rendered)
+		}
+
+		// Restore the index
+		p.messageList.SelectedRow = i
+		if i > len(p.messageList.Rows)-1 {
+			p.messageList.SelectedRow--
+		}
+		return
+	}
+
+	// TODO - delete when viewing a single message.
+}
+
 // showUI handles state-transitions and displays
 //
 // All our code is built around a set of list-views,
@@ -274,6 +318,11 @@ Steve
 				for _, r := range p.messages {
 					p.messageList.Rows = append(p.messageList.Rows, r.Rendered)
 				}
+			}
+		case "d":
+			if p.mode == "messages" ||
+				p.mode == "message" {
+				p.deleteCurrentMessage()
 			}
 		case "j", "<Down>":
 			widget.ScrollDown()


### PR DESCRIPTION
This pull-request will close #11, once complete.  There will
be two natural ways to delete a message:

* Pressing `d` when viewing the list of messages in a folder.
  * This deletes the line under the point.
  * Implemented.
* Pressing `d` when viewing a single message.
  * The expectation is that the view of the current message will be
replaced, with the previous/next.
  * This is still TODO

However I've stalled on this because I'm spotting a problem which
is gonna be a dealbreaker:

* I want to implement "Reply" to messages in #10, but I cannot.

The specific problem there is similar to this one we want to operate
upon a single message, be it:

* The one under the cursor, when viewing the message-list.
* The current-message if viewing a single one.

That's fine, I can do that.  Then I format the message, spawn
the editor, and prepare the message.  Of course the problem then
raises its head:

* I format the message
 * "On $date $sender wrote: "
 * "> blah .."
 * "> blah"
* I spawn vim/emacs/whatever
* The user exits the message
* I want to say "Send mail: y/n?"
  * BUT I CANNOT
  * The UI toolikit I chose does NOT support any input-widgets

So I'm screwed.  I need to either:

* Change toolkit
* Write a widget (yeah, not gonna happen)

And now I've seen this problem coming I'm gonna stop deleting :)